### PR TITLE
Add browserify and browserify-shim to dependences

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,11 +38,11 @@
     "jshint": "2.5.x",
     "jsgreat": "0.1.1",
     "q": "1.0.1",
-    "jquery": "1.11.x"
+    "jquery": "1.11.x",
+    "browserify": "4.1.x",
+    "browserify-shim": "3.5.x"
   },
   "devDependencies": {
-    "browserify": "4.1.x",
-    "browserify-shim": "3.5.x",
     "bower": "1.3.x",
     "jsgreat": "0.1.1"
   }


### PR DESCRIPTION
We cannot expect that a project that is using funct-unit is already shiming libraries.
