### PR TITLE
add timeout setter to main export, bump dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
 # CHANGELOG
 
-* 0.0.1 - Initial release, moved over all funcunit-as-promised code from myyola
+## 0.0.4
+
+* add timeout setter on main export
+
+## 0.0.1
+
+* Initial release, moved over all funcunit-as-promised code from myyola

--- a/index.js
+++ b/index.js
@@ -8,6 +8,10 @@ var frameNumber = false;
 
 var exports = {};
 
+exports.setTimeout = function(timeout) {
+  this.timeout = timeout;
+};
+
 exports.switchToFrame = function(newFrameNumber){
     return q.fcall(function(){
         frameNumber = newFrameNumber;
@@ -63,7 +67,8 @@ exports.assertVisible = function(selector){
         evaluator: isVisible,
         args: {
             selector: selector
-        }
+        },
+        timeout: exports.timeout
     });
 };
 
@@ -73,7 +78,8 @@ exports.assertAnyVisible = function(selectors){
         evaluator: anyVisible,
         args: {
             selectors: selectors
-        }
+        },
+        timeout: exports.timeout
     });
 };
 
@@ -84,7 +90,8 @@ exports.assertTextEquals = function(selector, expectedText){
         args: {
             selector: selector,
             expectedText: expectedText
-        }
+        },
+        timeout: exports.timeout
     });
 };
 
@@ -95,7 +102,8 @@ exports.assertSize = function(selector, expectedSize){
         args: {
             selector: selector,
             expectedSize: expectedSize
-        }
+        },
+        timeout: exports.timeout
     });
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "funcunit-as-promised",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Promise based interface for funcunit",
   "main": "index.js",
   "scripts": {
@@ -35,15 +35,14 @@
   },
   "homepage": "https://github.com/yola/funcunit-as-promised",
   "dependencies": {
-    "jshint": "2.5.x",
-    "jsgreat": "0.1.1",
-    "q": "1.0.1",
+    "jshint": "~2.9.1",
+    "jsgreat": "~0.1.6",
+    "q": "~1.4.1",
     "jquery": "1.11.x",
-    "browserify": "4.1.x",
-    "browserify-shim": "3.5.x"
+    "browserify": "~13.0.0",
+    "browserify-shim": "~3.8.12"
   },
   "devDependencies": {
-    "bower": "1.3.x",
-    "jsgreat": "0.1.1"
+    "bower": "~1.7.7"
   }
 }


### PR DESCRIPTION
- modernize dependencies to avoid potential issues with node 4, 5.
- add setter function for overriding default timeout value for `poller.js`, so longer running tests don't have to eat it.
